### PR TITLE
Fix Build Badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Minimal C++ Starter
 
-[![build status](https://img.shields.io/github/workflow/status/threeal/minimal-cpp-starter/build)](https://github.com/threeal/minimal-cpp-starter/actions/workflows/build.yml)
+[![build status](https://img.shields.io/github/actions/workflow/status/threeal/minimal-cpp-starter/build.yml?branch=main)](https://github.com/threeal/minimal-cpp-starter/actions/workflows/build.yml)
 
 A minimal C++ template to kickstart your project.


### PR DESCRIPTION
Fix build badge URL as mentioned in https://github.com/badges/shields/issues/8671.