### PR TITLE
Add Warning Flags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         run: pip3 install cmake-format
 
       - name: Configure CMake
-        run: cmake . -B build -DBUILD_TESTING=ON
+        run: cmake . -B build -DBUILD_TESTING=ON -DCMAKE_CXX_FLAGS='-Werror'
 
       - name: Check for code formatting
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.0)
 
 project(example)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic")
+
 include(cmake/CPM.cmake)
 cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
 


### PR DESCRIPTION
- Add C++ compiler flags that enable warning.
- Treat warning as error on the build workflow during test job.