### PR TITLE
Test for Code Coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,3 +41,9 @@ jobs:
 
       - name: Run tests
         run: ctest --test-dir build --verbose
+
+      - name: Install gcovr
+        run: pip3 install gcovr
+
+      - name: Test for code coverage
+        run: gcovr --fail-under-line 80

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,4 +46,5 @@ jobs:
         run: pip3 install gcovr
 
       - name: Test for code coverage
-        run: gcovr --fail-under-line 80
+        run: gcovr -e 'build/*' --fail-under-line 80
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,11 @@ target_include_directories(example PUBLIC include)
 
 if(BUILD_TESTING)
   enable_testing()
+
   cpmaddpackage("gh:catchorg/Catch2@3.2.0")
   include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
+
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -fPIC -O0")
 
   add_executable(example_test test/example_test.cpp)
   target_link_libraries(example_test PRIVATE example Catch2::Catch2WithMain)


### PR DESCRIPTION
- Add compiler flags that enable code coverage test of this project.
- Check for code coverage on `build.yml` workflow using [gcovr](https://gcovr.com/en/master/index.html).