### PR TITLE
Bump Catch2 to v3.3.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   if(BUILD_TESTING)
     enable_testing()
 
-    cpmaddpackage("gh:catchorg/Catch2@3.2.0")
+    cpmaddpackage("gh:catchorg/Catch2@3.3.2")
     include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -fPIC -O0")


### PR DESCRIPTION
Bump [Catch2](https://github.com/catchorg/Catch2) to the [latest version (v3.3.2)](https://github.com/catchorg/Catch2/releases/tag/v3.3.2).