### PR TITLE
Ignore All Dot Prefixed Files in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
+.*
+!.clang*
+!.cmake*
+!.git*
+
 build


### PR DESCRIPTION
- Added Git ignore rules to exclude most dot-prefixed files except Clang, CMake, and Git files.
- Closes #25.