### PR TITLE
Prevent Formatting of CPM Package Lock File

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -1,14 +1,4 @@
 {
-    "additional_commands": {
-        "cpmdeclarepackage": {
-            "kwargs": {
-                "VERSION": 1,
-                "GITHUB_REPOSITORY": 1,
-                "SYSTEM": 1,
-                "EXCLUDE_FROM_ALL": 1
-            }
-        }
-    },
     "enable_markup": false,
     "line_width": 120
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ target_include_directories(example PUBLIC include)
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   include(cmake/CPM.cmake)
-  cpmusepackagelock(package-lock.cmake)
+  cpmusepackagelock(package-lock)
   cpmgetpackage(Format.cmake)
 
   if(BUILD_TESTING)

--- a/package-lock
+++ b/package-lock
@@ -2,16 +2,16 @@
 # This file should be committed to version control
 
 # Format.cmake
-cpmdeclarepackage(
-  Format.cmake
+CPMDeclarePackage(Format.cmake
   VERSION 1.7.3
   GITHUB_REPOSITORY TheLartians/Format.cmake
   SYSTEM YES
-  EXCLUDE_FROM_ALL YES)
+  EXCLUDE_FROM_ALL YES
+)
 # Catch2
-cpmdeclarepackage(
-  Catch2
+CPMDeclarePackage(Catch2
   VERSION 3.4.0
   GITHUB_REPOSITORY catchorg/Catch2
   SYSTEM YES
-  EXCLUDE_FROM_ALL YES)
+  EXCLUDE_FROM_ALL YES
+)


### PR DESCRIPTION
This pull request ensures that the CPM package lock file is not subjected to formatting by making the following changes:

- Renamed the CPM package lock file to `package-lock`.
- Removed the configuration for the `cpmdeclarepackage` function in the cmake-format configuration.

This change resolves #39.